### PR TITLE
Fixed json parsing bug

### DIFF
--- a/practice-app/backend/controllers/quoteOfTheDay.js
+++ b/practice-app/backend/controllers/quoteOfTheDay.js
@@ -28,7 +28,7 @@ module.exports.getQuote = async function (request, response) {
             //Getting rid of the parantheses
             body = body.substring(2, body.length - 1)
             //Getting rid of the escape characters which cause parsing error
-            body = body.replace("\\", "")
+            body = body.replace(/\\/g, "")
             bodyJson = JSON.parse(body)
 
             // Set the response body.


### PR DESCRIPTION
#89 Fixed the mentioned bug by globally deleting all escape characters. Did not get any errors with quotes having multiple escape characters.