### PR TITLE
(bknd) products are not sorted by price #366

### DIFF
--- a/backend/product_service/views/product.js
+++ b/backend/product_service/views/product.js
@@ -141,11 +141,6 @@ module.exports.getProducts = async (params) => {
 
     if (!!params.sortingFactor) {
       try {
-        console.log("Sorting factor : ", products[0][params.sortingFactor])
-        console.log("Type of sorting factor 1",typeof products[0][params.sortingFactor])
-        console.log("Type of sorting factor 2",typeof(products[0][params.sortingFactor]))
-
-
         if (typeof(products[0][params.sortingFactor]) == "number") {
           products = products.sort(
             (product1, product2) =>

--- a/backend/product_service/views/product.js
+++ b/backend/product_service/views/product.js
@@ -141,7 +141,12 @@ module.exports.getProducts = async (params) => {
 
     if (!!params.sortingFactor) {
       try {
-        if (typeof products[0][params.sortingFactor] == Number) {
+        console.log("Sorting factor : ", products[0][params.sortingFactor])
+        console.log("Type of sorting factor 1",typeof products[0][params.sortingFactor])
+        console.log("Type of sorting factor 2",typeof(products[0][params.sortingFactor]))
+
+
+        if (typeof(products[0][params.sortingFactor]) == "number") {
           products = products.sort(
             (product1, product2) =>
               (params.sortingType == "descending" ? -1 : 1) *


### PR DESCRIPTION
Deadline:28.12.2020
https://github.com/bounswe/bounswe2020group4/issues/366
Describe the bug
When I try to sort the products by ascending price, they are not returned in correct order.

To Reproduce

GET http://3.138.113.101:8080/products?categories=["Cosmetics","Skincare"]&sortingFactor=price&sortingType=ascending
Observe that the products are not returned in correct order
Expected behavior
Products should be sorted by ascending price.