### PR TITLE
Change productId to _id in update product status.

### DIFF
--- a/backend/checkout_service/views/order.js
+++ b/backend/checkout_service/views/order.js
@@ -201,13 +201,13 @@ module.exports.updateProductStatus = async (params) => {
       orderedProduct = await OrderedProduct.findOne({
         orderId: params.orderId,
         customerId: ObjectId(params.userId),
-        productId: ObjectId(params.productId),
+        _id: ObjectId(params.productId),
       });
     } else if (params.userType == "vendor") {
       orderedProduct = await OrderedProduct.findOne({
         orderId: params.orderId,
         vendorId: ObjectId(params.userId),
-        productId: ObjectId(params.productId),
+        _id: ObjectId(params.productId),
       });
     } else {
       return { success: false, message: ErrorMessage.WRONG_USER_TYPE };


### PR DESCRIPTION
Get the ordered product by its orderedProductId instead of general product id to avoid wrong status updates.

Closes #487  